### PR TITLE
adding tia app template repo

### DIFF
--- a/.github/workflows/tia-deploy.yml
+++ b/.github/workflows/tia-deploy.yml
@@ -43,6 +43,14 @@ on:
         - '1.22'
         - '1.23'
         - '1.24'
+      apptemplates:
+        description: 'Use Portainer-in-Portainer App Templates: true or false'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'false'
+        - 'true'
       environment_duration:
         description: 'Duration of the environment: Specify `8h` (default), `1d`, `3d`, `5d` or `10d`'
         required: true
@@ -139,7 +147,8 @@ jobs:
           --raw-field environment_os=${{ github.event.inputs.environment_os }} \
           --raw-field environment_orchestration=${{ github.event.inputs.environment_orchestration }} \
           --raw-field kubernetes_version=${{ github.event.inputs.kubernetes_version }} \
-          --raw-field feature_flags='' \
+          # --raw-field feature_flags='' \
+          --raw-field apptemplates=${{ github.event.inputs.apptemplates }} \
           --raw-field test_automation=false \
           --raw-field cypress_specs='' \
           --raw-field environment_prefix=${TIA_PREFIX} \


### PR DESCRIPTION
Adds an input option to be able to choose to use the App Template repo in the Platform repo for Portainer standalone and swarm (lin and arm ONLY).  The app templates in this repo have Portainer-in-Portainer (dind) apps so that manual testing can be done on Portainer without having to use TIA to spin up more environments if the test case fits.

The default setting for this is false, which means the public Portainer Apps template repo is used.  This is important as QA run tests against this repo also.

This PR is submitted to call the infrastructure deploy workflow with the correct inputs.