### PR TITLE
Fix portainer-agent chart ServiceAccount naming [PLA-709]

### DIFF
--- a/charts/portainer-agent/templates/deployment.yaml
+++ b/charts/portainer-agent/templates/deployment.yaml
@@ -85,11 +85,6 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-            {{- if or (eq .Values.deploymentMode "edge") (eq .Values.deploymentMode "edge-async") }}
-            - name: edge
-              containerPort: 80
-              protocol: TCP
-            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.mtls.existingSecret }}

--- a/charts/portainer-agent/templates/deployment.yaml
+++ b/charts/portainer-agent/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "portainer-agent.fullname" . }}
+      serviceAccountName: {{ include "portainer-agent.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -85,6 +85,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if or (eq .Values.deploymentMode "edge") (eq .Values.deploymentMode "edge-async") }}
+            - name: edge
+              containerPort: 80
+              protocol: TCP
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.mtls.existingSecret }}

--- a/charts/portainer-agent/templates/rbac.yaml
+++ b/charts/portainer-agent/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "portainer-agent.fullname" . }}
+  name: {{ include "portainer-agent.serviceAccountName" . }}-crb
   labels:
     {{- include "portainer-agent.labels" . | nindent 4 }}
 roleRef:
@@ -11,6 +11,6 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "portainer-agent.fullname" . }}
+    name: {{ include "portainer-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }} 

--- a/charts/portainer-agent/templates/serviceaccount.yaml
+++ b/charts/portainer-agent/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "portainer-agent.fullname" . }}
+  name: {{ include "portainer-agent.serviceAccountName" . }}
   labels:
     {{- include "portainer-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/portainer-agent/values.yaml
+++ b/charts/portainer-agent/values.yaml
@@ -89,7 +89,7 @@ serviceAccount:
   annotations: {}
   # Name of the service account to use
   # If not set, a name is generated using the fullname template
-  name: ""
+  name: portainer-sa-clusteradmin
 
 # Pod security context
 podSecurityContext: {}


### PR DESCRIPTION
## Summary

- The unified `portainer-agent` helm chart was using the `fullname` helper for ServiceAccount/ClusterRoleBinding naming, producing names like `portainer-agent` instead of `portainer-sa-clusteradmin`
- This caused kubectl-shell to fail on edge agent clusters (proxmox clusters 2 & 3) where no server chart is present to create the expected SA
- The legacy `agent`, `edge`, and `edge-async` charts all defaulted to `portainer-sa-clusteradmin` — the unified chart missed this

## Changes

- Default `serviceAccount.name` to `portainer-sa-clusteradmin` in `values.yaml`
- Use `serviceAccountName` helper (already existed in `_helpers.tpl`) in `serviceaccount.yaml`, `rbac.yaml`, and `deployment.yaml`
- Name ClusterRoleBinding as `portainer-sa-clusteradmin-crb` (matches `portainer-crb-` cleanup pattern)
- Add container port 80 for edge/edge-async modes (matching official manifest)

## Companion PR

- portainer/internal-platforms — disables SA creation where server chart already provides it

## Test plan

- [ ] `helm template` dry-run for agent, edge, and edge-async modes confirms SA named `portainer-sa-clusteradmin`
- [ ] `helm template` with `serviceAccount.create=false` produces no SA/CRB but deployment still references `portainer-sa-clusteradmin`
- [ ] Deploy on proxmox kubernetes TIA — verify kubectl-shell works on edge agent environments
- [ ] Deploy on vSphere — verify no helm ownership conflicts with companion PR